### PR TITLE
Reducing the scope of tables

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -415,10 +415,13 @@ optgroup {
 
 table {
   border-collapse: collapse;
+}
+
+table:not[cellspacing] {
   border-spacing: 0;
 }
 
-td,
-th {
+table:not[cellpadding] td,
+table:not[cellpadding] th {
   padding: 0;
 }


### PR DESCRIPTION
CKEditor (and other wysiwyg editor ?) still adds these attributes to tables to manage padding and margin between table cells. Reducing the scope to tables:not using these attributes would be nicer for legacy contents. (No support for IE8).
